### PR TITLE
Apply target for kkarczmarczyk/node-yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kkarczmarczyk/node-yarn:7.0
+FROM kkarczmarczyk/node-yarn:8.0
 
 # if you're in China, please comment above image and uncomment following image :)
 


### PR DESCRIPTION
Apply target `docker-base-image::kkarczmarczyk/node-yarn`:

**New Docker Base Image Tag Update**
Target tag for Docker base image *kkarczmarczyk/node-yarn* is `8.0`.
Project *sdm-org/cd-docker-52/master* is currently using tag `7.0`.

_Docker base images_
```kkarczmarczyk/node-yarn (8.0)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:docker-base-image::kkarczmarczyk/node-yarn=716a78da469a1d6a8e1ca84885c39670fe2afeb7bb902bdb16f6f2510eae0f92]</code>
</details>